### PR TITLE
Support for float parsing

### DIFF
--- a/src/api/parser.rs
+++ b/src/api/parser.rs
@@ -163,6 +163,8 @@ fn parse_primitive_member(value: &rmpv::Value) -> Result<PklPrimitive> {
                 return Err(Error::ParseError(format!("expected integer, got {:?}", n)));
             }
         }
+        rmpv::Value::F32(f) => Ok(PklPrimitive::Float(*f as f64)),
+        rmpv::Value::F64(f) => Ok(PklPrimitive::Float(*f)),
         _ => {
             todo!("parse other primitive types. value: {}", value);
         }


### PR DESCRIPTION
This is probably a bit buggy, might want to implement a couple different variants of the float to support the f32 and f64

For the moment, this passes the test